### PR TITLE
Attempted to template CF with Jinja2

### DIFF
--- a/playbooks/provisioning/aws/cloudformation-jinja/render.py
+++ b/playbooks/provisioning/aws/cloudformation-jinja/render.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+from jinja2 import Environment, FileSystemLoader
+from os.path import abspath, dirname, join
+import sys
+
+template_dir = abspath(join(dirname(__file__), 'templates'))
+template = sys.argv[1] + '.j2'
+context = {}
+if len(sys.argv) > 2:
+	for arg in sys.argv[2:]:
+		key, value = arg.split('=')
+		if value.isdecimal():
+			value = int(value)
+		context[key] = value
+
+env = Environment(loader=FileSystemLoader(template_dir))
+env.globals=context
+
+print(env.get_template(template).render())

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
@@ -26,6 +26,10 @@ Parameters:
 {%- endblock vpc_parameters %}
 
 {%- set security_groups = ['ETCD', 'Node', 'Router', 'Master', 'RouterELB', 'MasterExternalELB', 'MasterInternalELB'] %}
+{%- macro security_group(name) -%}
+{{ name }}SecurityGroup
+{%- endmacro -%}
+
 {%- block security_group_parameters %}
 {%- if openshift_aws_provision_security_groups %}
   SecurityGroupTemplateURL:
@@ -33,7 +37,7 @@ Parameters:
     Default: '{% block security_group_default_template %}https://s3.amazonaws.com/openshift-cloudformation-templates/security-groups/default.yaml{% endblock security_group_default_template %}'
 {%- else %}
 {%- for group in security_groups %}
-  {{ group }}SecurityGroups:
+  {{ security_group(group) }}s:
     Type: 'List<AWS::EC2::SecurityGroup::Id>'
 {%- endfor %}
 {%- endif %}
@@ -119,7 +123,7 @@ Resources:
         NodeInstanceProfile:             {{ get_or_ref(openshift_aws_provision_iam_profiles, 'IAMStack', 'NodeInstanceProfile') }}
         MasterInstanceProfile:           {{ get_or_ref(openshift_aws_provision_iam_profiles, 'IAMStack', 'MasterInstanceProfile') }}
 {%- for group in security_groups %}
-{%- set group_name = group ~ 'SecurityGroups' %}
+{%- set group_name = security_group(group) ~ s %}
         {{ '%-32s %s' | format(group_name ~ ':', get_or_ref(openshift_aws_provision_security_groups, 'SecurityGroupStack', group_name)) }}
 {%- endfor %}
 {%- endblock control_plane_stack_definition %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
@@ -25,14 +25,15 @@ Parameters:
 {%- endif %}
 {%- endblock vpc_parameters %}
 
+{%- set security_groups = ['ETCD', 'Node', 'Router', 'Master', 'RouterELB', 'MasterExternalELB', 'MasterInternalELB'] %}
 {%- block security_group_parameters %}
 {%- if openshift_aws_provision_security_groups %}
   SecurityGroupTemplateURL:
     Type: String
     Default: '{% block security_group_default_template %}https://s3.amazonaws.com/openshift-cloudformation-templates/security-groups/default.yaml{% endblock security_group_default_template %}'
 {%- else %}
-{%- for type in ['ETCD', 'Node', 'Router', 'Master', 'RouterELB', 'MasterExternalELB', 'MasterInternalELB'] %}
-  {{ type }}SecurityGroups:
+{%- for group in security_groups %}
+  {{ group }}SecurityGroups:
     Type: 'List<AWS::EC2::SecurityGroup::Id>'
 {%- endfor %}
 {%- endif %}
@@ -84,10 +85,6 @@ Resources:
 {%- endif %}
 {%- endmacro %}
 
-{%- macro get_or_ref_security_group(var) -%}
-{{ get_or_ref(openshift_aws_provision_security_groups, 'SecurityGroupStack', var ~ 'SecurityGroups') }}
-{%- endmacro %}
-
 {%- block security_group_stack_definition %}
 {%- if openshift_aws_provision_security_groups %}
   SecurityGroupStack:
@@ -121,11 +118,8 @@ Resources:
         MasterUserData:                  !Ref MasterUserData
         NodeInstanceProfile:             {{ get_or_ref(openshift_aws_provision_iam_profiles, 'IAMStack', 'NodeInstanceProfile') }}
         MasterInstanceProfile:           {{ get_or_ref(openshift_aws_provision_iam_profiles, 'IAMStack', 'MasterInstanceProfile') }}
-        ETCDSecurityGroups:              {{ get_or_ref_security_group('ETCD') }}
-        NodeSecurityGroups:              {{ get_or_ref_security_group('Node') }}
-        RouterSecurityGroups:            {{ get_or_ref_security_group('Router') }}
-        MasterSecurityGroups:            {{ get_or_ref_security_group('Master') }}
-        RouterELBSecurityGroups:         {{ get_or_ref_security_group('RouterELB') }}
-        MasterExternalELBSecurityGroups: {{ get_or_ref_security_group('MasterExternalELB') }}
-        MasterInternalELBSecurityGroups: {{ get_or_ref_security_group('MasterInternalELB') }}
+{%- for group in security_groups %}
+{%- set group_name = group ~ 'SecurityGroups' %}
+        {{ '%-32s %s' | format(group_name ~ ':', get_or_ref(openshift_aws_provision_security_groups, 'SecurityGroupStack', group_name)) }}
+{%- endfor %}
 {%- endblock control_plane_stack_definition %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
@@ -1,0 +1,131 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: OpenShift Cluster Template
+Parameters:
+  NamePrefix:
+    Type: String
+  MasterAPIPort:
+    Type: Number
+  KeyName:
+    Type: 'AWS::EC2::KeyPair::KeyName'
+
+{%- block vpc_parameters %}
+{%- if openshift_aws_provision_vpc %}
+  VPCTemplateURL:
+    Type: String
+    Default: '{% block vpc_default_template %}https://s3.amazonaws.com/openshift-cloudformation-templates/vpc/default.yaml{% endblock vpc_default_template %}'
+  VPCCIDRBlock:
+    Type: String
+  SubnetCIDRBlocks:
+    Type: CommaDelimitedList
+  SubnetAvailabilityZones:
+    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+{%- else %}
+  VPC:
+    Type: 'AWS::EC2::VPC::Id'
+{%- endif %}
+{%- endblock vpc_parameters %}
+
+{%- block security_group_parameters %}
+{%- if openshift_aws_provision_security_groups %}
+  SecurityGroupTemplateURL:
+    Type: String
+    Default: '{% block security_group_default_template %}https://s3.amazonaws.com/openshift-cloudformation-templates/security-groups/default.yaml{% endblock security_group_default_template %}'
+{%- else %}
+{%- for type in ['ETCD', 'Node', 'Router', 'Master', 'RouterELB', 'MasterExternalELB', 'MasterInternalELB'] %}
+  {{ type }}SecurityGroups:
+    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+{%- endfor %}
+{%- endif %}
+{%- endblock security_group_parameters %}
+
+{%- block iam_profile_parameters %}
+{%- if openshift_aws_provision_iam_profiles %}
+  IAMInstanceProfileTemplateURL:
+    Type: String
+    Default: '{% block iam_profile_default_template %}https://s3.amazonaws.com/openshift-cloudformation-templates/iam-profiles/default.yaml{% endblock iam_profile_default_template %}'
+{%- else %}
+  MasterInstanceProfile:
+    Type: String
+  NodeInstanceProfile:
+    Type: String
+{%- endif %}
+{%- endblock iam_profile_parameters %}
+
+{%- block control_plane_parameters %}
+  MasterUserData:
+    Type: String
+  MasterInstanceSubnets:
+    Type: 'List<AWS::EC2::Subnet::Id>'
+  ControlPlaneTemplateURL:
+    Type: String
+    Default: '{% block control_plane_default_template %}https://s3.amazonaws.com/openshift-cloudformation-templates/control-plane/default.yaml{% endblock control_plane_default_template %}'
+{%- endblock control_plane_parameters %}
+
+Resources:
+{%- block vpc_stack_definition %}
+{%- if openshift_aws_provision_vpc %}
+  VPCStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Ref VPCTemplateURL
+      Parameters:
+        VPCName:                 !Join ['', [!Ref NamePrefix, '_vpc']]
+        VPCCIDRBlock:            !Ref VPCCIDRBlock
+        SubnetCIDRBlocks:        !Ref SubnetCIDRBlocks
+        SubnetAvailabilityZones: !Ref SubnetAvailabilityZones
+{%- endif %}
+{%- endblock vpc_stack_definition %}
+
+{%- macro get_or_ref(control_var, stack, var) -%}
+{% if control_var -%}
+!GetAtt {{ stack }}.Outputs.{{ var }}
+{%- else -%}
+!Ref {{ var }}
+{%- endif %}
+{%- endmacro %}
+
+{%- macro get_or_ref_security_group(var) -%}
+{{ get_or_ref(openshift_aws_provision_security_groups, 'SecurityGroupStack', var ~ 'SecurityGroups') }}
+{%- endmacro %}
+
+{%- block security_group_stack_definition %}
+{%- if openshift_aws_provision_security_groups %}
+  SecurityGroupStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Ref SecurityGroupTemplateURL
+      Parameters:
+        VPC:           {{ get_or_ref(openshift_aws_provision_vpc, 'VPCStack', 'VPC') }}
+        MasterAPIPort: !Ref MasterAPIPort
+{%- endif %}
+{%- endblock security_group_stack_definition %}
+
+{%- block iam_profile_stack_definition %}
+{%- if openshift_aws_provision_iam_profiles %}
+  IAMStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Ref IAMInstanceProfileTemplateURL
+{%- endif %}
+{%- endblock iam_profile_stack_definition %}
+
+{%- block control_plane_stack_definition %}
+  ControlPlaneStack:
+    Type: 'AWS::CloudFormation::Stack'
+    Properties:
+      TemplateURL: !Ref ControlPlaneTemplateURL
+      Parameters:
+        KeyName:                         !Ref KeyName
+        MasterSubnets:                   {{ get_or_ref(openshift_aws_provision_vpc, 'VPCStack', 'MasterInstanceSubnets') }}
+        MasterAPIPort:                   !Ref MasterAPIPort
+        MasterUserData:                  !Ref MasterUserData
+        NodeInstanceProfile:             {{ get_or_ref(openshift_aws_provision_iam_profiles, 'IAMStack', 'NodeInstanceProfile') }}
+        MasterInstanceProfile:           {{ get_or_ref(openshift_aws_provision_iam_profiles, 'IAMStack', 'MasterInstanceProfile') }}
+        ETCDSecurityGroups:              {{ get_or_ref_security_group('ETCD') }}
+        NodeSecurityGroups:              {{ get_or_ref_security_group('Node') }}
+        RouterSecurityGroups:            {{ get_or_ref_security_group('Router') }}
+        MasterSecurityGroups:            {{ get_or_ref_security_group('Master') }}
+        RouterELBSecurityGroups:         {{ get_or_ref_security_group('RouterELB') }}
+        MasterExternalELBSecurityGroups: {{ get_or_ref_security_group('MasterExternalELB') }}
+        MasterInternalELBSecurityGroups: {{ get_or_ref_security_group('MasterInternalELB') }}
+{%- endblock control_plane_stack_definition %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/cluster.j2
@@ -25,7 +25,12 @@ Parameters:
 {%- endif %}
 {%- endblock vpc_parameters %}
 
-{%- set security_groups = ['ETCD', 'Node', 'Router', 'Master', 'RouterELB', 'MasterExternalELB', 'MasterInternalELB'] %}
+{%- set core_security_groups = ['ETCD', 'Node', 'Router', 'Master', 'RouterELB'] %}
+{%- if openshift_aws_num_masters > 1 %}
+{%- set security_groups = core_security_groups + ['MasterExternalELB', 'MasterInternalELB'] %}
+{%- else %}
+{%- set security_groups = core_security_groups %}
+{%- endif %}
 {%- macro security_group(name) -%}
 {{ name }}SecurityGroup
 {%- endmacro -%}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/control_plane.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/control_plane.j2
@@ -3,10 +3,12 @@ Description: OpenShift Integrated Control Plane
 Parameters:
   MasterSecurityGroups:
     Type: 'List<AWS::EC2::SecurityGroup::Id>'
+{%- if openshift_aws_num_masters > 1 %}
   MasterExternalELBSecurityGroups:
     Type: 'List<AWS::EC2::SecurityGroup::Id>'
   MasterInternalELBSecurityGroups:
     Type: 'List<AWS::EC2::SecurityGroup::Id>'
+{%- endif %}
   MasterInstanceType:
     Type: String
   MasterImageID:
@@ -53,6 +55,7 @@ Resources:
 {%- endfor %}
       UserData: !Ref MasterUserData
 {%- endfor %}
+{%- if openshift_aws_num_masters > 1 %}
 {%- for name, scheme in [('External', 'internet-facing'), ('Internal', 'internal')] %}
   Master{{ name }}LoadBalancer:
     Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
@@ -79,3 +82,4 @@ Resources:
         UnhealthyThreshold: 2
         Target: !Join ['', ['https:', !Ref MasterAPIPort, '/healthz/ready']]
 {%- endfor %}
+{%- endif %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/control_plane.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/control_plane.j2
@@ -1,0 +1,81 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: OpenShift Integrated Control Plane
+Parameters:
+  MasterSecurityGroups:
+    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+  MasterExternalELBSecurityGroups:
+    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+  MasterInternalELBSecurityGroups:
+    Type: 'List<AWS::EC2::SecurityGroup::Id>'
+  MasterInstanceType:
+    Type: String
+  MasterImageID:
+    Type: 'AWS::EC2::Image::Id'
+  MasterInstanceProfile:
+    Type: String
+  KeyName:
+    Type: 'AWS::EC2::KeyPair::KeyName'
+  MasterSubnets:
+    Type: 'List<AWS::EC2::Subnet::Id>'
+  MasterAPIPort:
+    Type: Number
+    Default: 443
+  MasterRootVolSize:
+    Type: String
+    Default: 10
+  MasterDockerVolSize:
+    Type: String
+    Default: 25
+  MasterETCDVolSize:
+    Type: String
+    Default: 25
+  MasterUserData:
+    Type: String
+
+Resources:
+{%- for i in range(openshift_aws_num_masters) %}
+  Master{{ i }}:
+    Type: 'AWS::EC2::Instance'
+    Properties:
+      ImageId:            !Ref MasterImageID
+      KeyName:            !Ref KeyName
+      SubnetId:           !Select [{{ i }}, !Ref MasterSubnets]
+      InstanceType:       !Ref MasterInstanceType
+      SecurityGroupIds:   !Ref MasterSecurityGroups
+      IamInstanceProfile: !Ref MasterInstanceProfile
+      BlockDeviceMappings:
+{%- for device, name in [('sda1', 'Root'), ('xvdb', 'Docker'), ('xvdc', 'ETCD')] %}
+        - DeviceName: /dev/{{ device }}
+          Ebs:
+            VolumeSize:          !Ref Master{{ name }}VolSize
+            VolumeType:          gp2
+            DeleteOnTermination: True
+{%- endfor %}
+      UserData: !Ref MasterUserData
+{%- endfor %}
+{%- for name, scheme in [('External', 'internet-facing'), ('Internal', 'internal')] %}
+  Master{{ name }}LoadBalancer:
+    Type: 'AWS::ElasticLoadBalancing::LoadBalancer'
+    Properties:
+      CrossZone: True
+      ConnectionSettings:
+        IdleTimeout: 3600
+      Listeners:
+        - InstancePort:     !Ref MasterAPIPort
+          InstanceProtocol: tcp
+          LoadBalancerPort: !Ref MasterAPIPort
+          Protocol:         tcp
+      Scheme:         {{ scheme }}
+      SecurityGroups: !Ref Master{{ name }}ELBSecurityGroups
+      Subnets:        !Ref MasterSubnets
+      Instances:
+{%- for i in range(openshift_aws_num_masters) %}
+        - !Ref Master{{ i }}
+{%- endfor %}
+      HealthCheck:
+        HealthyThreshold: 2
+        Interval: 5
+        Timeout: 2
+        UnhealthyThreshold: 2
+        Target: !Join ['', ['https:', !Ref MasterAPIPort, '/healthz/ready']]
+{%- endfor %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/iam_profiles.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/iam_profiles.j2
@@ -1,0 +1,65 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: OpenShift IAM Profiles Template
+Resources:
+  MasterPolicy:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+      - PolicyName: openshift-master
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action: 'ec2:*'
+              Resource: '*'
+            - Effect: Allow
+              Action: 'elasticloadbalancing:*'
+              Resource: '*'
+  MasterInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    DependsOn: !Ref MasterPolicy
+    Properties:
+      Roles:
+        - !Ref MasterPolicy
+
+  NodePolicy:
+    Type: 'AWS::IAM::Role'
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - ec2.amazonaws.com
+            Action:
+              - 'sts:AssumeRole'
+      Policies:
+      - PolicyName: openshift-node
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action: 'ec2:Describe*'
+              Resource: '*'
+  NodeInstanceProfile:
+    Type: 'AWS::IAM::InstanceProfile'
+    DependsOn: !Ref NodePolicy
+    Properties:
+      Roles:
+        - !Ref NodePolicy
+
+Outputs:
+  MasterInstanceProfile:
+    Value: !Ref MasterInstanceProfile
+  NodeInstanceProfile:
+    Value: !Ref NodeInstanceProfile

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/lib/security_groups.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/lib/security_groups.j2
@@ -1,0 +1,19 @@
+{# These are the literal names of security groups we can create. #}
+{% set ssh        = 'SSH' %}
+{% set etcd       = 'ETCD' %}
+{% set node       = 'Node' %}
+{% set router     = 'Router' %}
+{% set router_elb = router ~ 'ELB' %}
+{% set master     = 'Master' %}
+{% set master_external_elb = master ~ 'ExternalELB' %}
+{% set master_internal_elb = master ~ 'InternalELB' %}
+
+{# security_group_for_name returns the name of the security group for the component. #}
+{%- macro security_group_for_name(name) -%}
+{{ name }}SecurityGroup
+{%- endmacro -%}
+
+{# security_grouping_for_name returns the name of the logical group of security groups for the component. #}
+{%- macro security_grouping_for_name(name) -%}
+{{ security_group_for_name(name) }}s
+{%- endmacro -%}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
@@ -6,230 +6,67 @@ Parameters:
   MasterAPIPort:
     Type: Number
 
+{%- from 'cluster.j2' import security_group, security_groups %}
+
 Resources:
-  MasterSecurityGroup:
+{%- for group in security_groups + ['SSH'] %}
+  {{ security_group(group) }}:
     Type: 'AWS::EC2::SecurityGroup'
     Properties:
-      GroupDescription: 'OpenShift Masters'
+      GroupDescription: 'OpenShift {{ group }}s'
       VpcId: !Ref VPC
-  MasterExternalELBSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'OpenShift Masters External Load-Balancer'
-      VpcId: !Ref VPC
-  MasterInternalELBSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'OpenShift Masters Internal Load-Balancer'
-      VpcId: !Ref VPC
-  NodeSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'OpenShift Nodes'
-      VpcId: !Ref VPC
-  ETCDSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'OpenShift etcd Hosts'
-      VpcId: !Ref VPC
-  RouterSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'OpenShift Routers'
-      VpcId: !Ref VPC
-  RouterELBSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'OpenShift Routers Load-Balancer'
-      VpcId: !Ref VPC
-  SSHSecurityGroup:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'SSH Access'
-      VpcId: !Ref VPC
+{%- endfor %}
 
-  SSHSecurityGroupIngress:
+{% macro external_ingress(destination, to_port, from_port='', identifier='') %}
+{%- if from_port == '' %}{%- set from_port = to_port %}{% endif -%}
+  {{ security_group(destination) ~ identifier }}Ingress:
     Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn: !Ref SSHSecurityGroup
+    DependsOn: !Ref {{ security_group(destination) }}
     Properties:
-      GroupId:    !Ref SSHSecurityGroup
+      GroupId:    !Ref {{ security_group(destination) }}
       CidrIp:     0.0.0.0/0
-      ToPort:     22
-      FromPort:   22
+      ToPort:     {{ to_port }}
+      FromPort:   {{ from_port }}
       IpProtocol: tcp
+{%- endmacro %}
 
-  MasterExternalELBSecurityGroupIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn: !Ref MasterExternalELBSecurityGroup
-    Properties:
-      GroupId:    !Ref MasterExternalELBSecurityGroup
-      CidrIp:     0.0.0.0/0
-      ToPort:     !Ref MasterAPIPort
-      FromPort:   !Ref MasterAPIPort
-      IpProtocol: tcp
+{{ external_ingress(destination='SSH',                                   to_port=22                  ) }}
+{{ external_ingress(destination='MasterExternalELB',                     to_port='!Ref MasterAPIPort') }}
+{{ external_ingress(destination='RouterELB',         identifier='HTTP',  to_port=80                  ) }}
+{{ external_ingress(destination='RouterELB',         identifier='HTTPS', to_port=443                 ) }}
 
-  RouterELBSecurityGroupHTTPIngress:
+{%- macro internal_ingress(destination, source, to_port, from_port='', identifier='', protocol='tcp') %}
+{%- if from_port == '' %}{%- set from_port = to_port %}{% endif -%}
+{%- if identifier == '' %}{%- set identifier = source %}{% endif -%}
+  {{ security_group(destination) ~ identifier }}Ingress:
     Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn: !Ref RouterELBSecurityGroup
+    DependsOn:
+      - !Ref {{ security_group(source) }}
+{%- if source != destination %}
+      - !Ref {{ security_group(destination) }}
+{%- endif %}
     Properties:
-      GroupId:    !Ref RouterELBSecurityGroup
-      CidrIp:     0.0.0.0/0
-      ToPort:     80
-      FromPort:   80
-      IpProtocol: tcp
-  RouterELBSecurityGroupHTTPsIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn: !Ref RouterELBSecurityGroup
-    Properties:
-      GroupId:    !Ref RouterELBSecurityGroup
-      CidrIp:     0.0.0.0/0
-      ToPort:     443
-      FromPort:   443
-      IpProtocol: tcp
+      GroupId:               !Ref {{ security_group(destination) }}
+      SourceSecurityGroupId: !Ref {{ security_group(source) }}
+      ToPort:                {{ to_port }}
+      FromPort:              {{ from_port }}
+      IpProtocol:            {{ protocol }}
+{%- endmacro %}
 
-  ETCDSecurityGroupMasterIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref ETCDSecurityGroup
-      - !Ref MasterSecurityGroup
-    Properties:
-      GroupId:               !Ref ETCDSecurityGroup
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort:                2379
-      FromPort:              2379
-      IpProtocol:            tcp
-  ETCDSecurityGroupETCDIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref ETCDSecurityGroup
-    Properties:
-      GroupId:               !Ref ETCDSecurityGroup
-      SourceSecurityGroupId: !Ref ETCDSecurityGroup
-      ToPort:                2380
-      FromPort:              2379
-      IpProtocol:            tcp
+{{ internal_ingress(destination='ETCD',              source='Master',                                  to_port=2379                ) }}
+{{ internal_ingress(destination='ETCD',              source='ETCD',                                    to_port=2380, from_port=2379) }}
+{{ internal_ingress(destination='Node',              source='Master',                                  to_port=10250               ) }}
+{{ internal_ingress(destination='Node',              source='Node',              identifier='Kubelet', to_port=10250               ) }}
+{{ internal_ingress(destination='Node',              source='Node',              identifier='VXLAN',   to_port=4789, protocol='udp') }}
+{{ internal_ingress(destination='Master',            source='Master',            identifier='API',     to_port='!Ref MasterAPIPort') }}
+{{ internal_ingress(destination='Master',            source='Node',                                    to_port='!Ref MasterAPIPort') }}
+{{ internal_ingress(destination='Master',            source='MasterInternalELB',                       to_port='!Ref MasterAPIPort') }}
+{{ internal_ingress(destination='Master',            source='MasterExternalELB',                       to_port='!Ref MasterAPIPort') }}
+{{ internal_ingress(destination='MasterInternalELB', source='Master',                                  to_port='!Ref MasterAPIPort') }}
+{{ internal_ingress(destination='MasterInternalELB', source='Node',                                    to_port='!Ref MasterAPIPort') }}
+{{ internal_ingress(destination='Router',            source='RouterELB',         identifier='HTTP',    to_port=80                  ) }}
+{{ internal_ingress(destination='Router',            source='RouterELB',         identifier='HTTPS',   to_port=443                 ) }}
 
-  NodeSecurityGroupMasterIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref NodeSecurityGroup
-      - !Ref MasterSecurityGroup
-    Properties:
-      GroupId:               !Ref NodeSecurityGroup
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort:                10250
-      FromPort:              10250
-      IpProtocol:            tcp
-  NodeSecurityGroupKubeletIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref NodeSecurityGroup
-    Properties:
-      GroupId:               !Ref NodeSecurityGroup
-      SourceSecurityGroupId: !Ref NodeSecurityGroup
-      ToPort:                10250
-      FromPort:              10250
-      IpProtocol:            tcp
-  NodeSecurityGroupVXLANIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref NodeSecurityGroup
-    Properties:
-      GroupId:               !Ref NodeSecurityGroup
-      SourceSecurityGroupId: !Ref NodeSecurityGroup
-      ToPort:                4789
-      FromPort:              4789
-      IpProtocol:            udp
-
-  MasterSecurityGroupMasterAPIIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref MasterSecurityGroup
-    Properties:
-      GroupId:               !Ref MasterSecurityGroup
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort:                !Ref MasterAPIPort
-      FromPort:              !Ref MasterAPIPort
-      IpProtocol:            tcp
-  MasterSecurityGroupNodeIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref MasterSecurityGroup
-      - !Ref NodeSecurityGroup
-    Properties:
-      GroupId:               !Ref MasterSecurityGroup
-      SourceSecurityGroupId: !Ref NodeSecurityGroup
-      ToPort:                !Ref MasterAPIPort
-      FromPort:              !Ref MasterAPIPort
-      IpProtocol:            tcp
-  MasterSecurityGroupMasterInternalELBIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref MasterSecurityGroup
-      - !Ref MasterInternalELBSecurityGroup
-    Properties:
-      GroupId:               !Ref MasterSecurityGroup
-      SourceSecurityGroupId: !Ref MasterInternalELBSecurityGroup
-      ToPort:                !Ref MasterAPIPort
-      FromPort:              !Ref MasterAPIPort
-      IpProtocol:            tcp
-  MasterSecurityGroupMasterExternalELBIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref MasterSecurityGroup
-      - !Ref MasterExternalELBSecurityGroup
-    Properties:
-      GroupId:               !Ref MasterSecurityGroup
-      SourceSecurityGroupId: !Ref MasterExternalELBSecurityGroup
-      ToPort:                !Ref MasterAPIPort
-      FromPort:              !Ref MasterAPIPort
-      IpProtocol:            tcp
-
-  MasterInternalELBSecurityGroupMasterIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref MasterInternalELBSecurityGroup
-      - !Ref MasterSecurityGroup
-    Properties:
-      GroupId:               !Ref MasterInternalELBSecurityGroup
-      SourceSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort:                !Ref MasterAPIPort
-      FromPort:              !Ref MasterAPIPort
-      IpProtocol:            tcp
-  MasterInternalELBSecurityGroupNodeIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref MasterInternalELBSecurityGroup
-      - !Ref NodeSecurityGroup
-    Properties:
-      GroupId:               !Ref MasterInternalELBSecurityGroup
-      SourceSecurityGroupId: !Ref NodeSecurityGroup
-      ToPort:                !Ref MasterAPIPort
-      FromPort:              !Ref MasterAPIPort
-      IpProtocol:            tcp
-
-  RouterSecurityGroupHTTPIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref RouterSecurityGroup
-      - !Ref RouterELBSecurityGroup
-    Properties:
-      GroupId:               !Ref RouterSecurityGroup
-      SourceSecurityGroupId: !Ref RouterELBSecurityGroup
-      ToPort:                80
-      FromPort:              80
-      IpProtocol:            tcp
-  RouterSecurityGroupHTTPSIngress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref RouterSecurityGroup
-      - !Ref RouterELBSecurityGroup
-    Properties:
-      GroupId:               !Ref RouterSecurityGroup
-      SourceSecurityGroupId: !Ref RouterELBSecurityGroup
-      ToPort:                443
-      FromPort:              443
-      IpProtocol:            tcp
 
   MasterExternalELBSecurityGroupEgress:
     Type: 'AWS::EC2::SecurityGroupEgress'

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
@@ -31,7 +31,9 @@ Resources:
 {%- endmacro %}
 
 {{ external_ingress(destination='SSH',                                   to_port=22                  ) }}
+{%- if openshift_aws_num_masters > 1 %}
 {{ external_ingress(destination='MasterExternalELB',                     to_port='!Ref MasterAPIPort') }}
+{%- endif %}
 {{ external_ingress(destination='RouterELB',         identifier='HTTP',  to_port=80                  ) }}
 {{ external_ingress(destination='RouterELB',         identifier='HTTPS', to_port=443                 ) }}
 
@@ -60,14 +62,17 @@ Resources:
 {{ internal_ingress(destination='Node',              source='Node',              identifier='VXLAN',   to_port=4789, protocol='udp') }}
 {{ internal_ingress(destination='Master',            source='Master',            identifier='API',     to_port='!Ref MasterAPIPort') }}
 {{ internal_ingress(destination='Master',            source='Node',                                    to_port='!Ref MasterAPIPort') }}
+{%- if openshift_aws_num_masters > 1 %}
 {{ internal_ingress(destination='Master',            source='MasterInternalELB',                       to_port='!Ref MasterAPIPort') }}
 {{ internal_ingress(destination='Master',            source='MasterExternalELB',                       to_port='!Ref MasterAPIPort') }}
 {{ internal_ingress(destination='MasterInternalELB', source='Master',                                  to_port='!Ref MasterAPIPort') }}
 {{ internal_ingress(destination='MasterInternalELB', source='Node',                                    to_port='!Ref MasterAPIPort') }}
+{%- endif %}
 {{ internal_ingress(destination='Router',            source='RouterELB',         identifier='HTTP',    to_port=80                  ) }}
 {{ internal_ingress(destination='Router',            source='RouterELB',         identifier='HTTPS',   to_port=443                 ) }}
 
 
+{%- if openshift_aws_num_masters > 1 %}
   MasterExternalELBSecurityGroupEgress:
     Type: 'AWS::EC2::SecurityGroupEgress'
     DependsOn: !Ref MasterExternalELBSecurityGroup
@@ -77,6 +82,7 @@ Resources:
       ToPort:                     !Ref MasterAPIPort
       FromPort:                   !Ref MasterAPIPort
       IpProtocol:                 tcp
+{%- endif %}
 
   RouterELBSecurityGroupHTTPEgress:
     Type: 'AWS::EC2::SecurityGroupEgress'
@@ -97,6 +103,7 @@ Resources:
       FromPort:                   443
       IpProtocol:                 tcp
 
+{%- if openshift_aws_num_masters > 1 %}
   MasterInternalELBSecurityGroupMasterEgress:
     Type: 'AWS::EC2::SecurityGroupEgress'
     DependsOn:
@@ -108,6 +115,7 @@ Resources:
       ToPort:                     !Ref MasterAPIPort
       FromPort:                   !Ref MasterAPIPort
       IpProtocol:                 tcp
+{%- endif %}
 
 Outputs:
   MasterSecurityGroups:
@@ -132,9 +140,11 @@ Outputs:
   RouterELBSecurityGroups:
     Value:
       - !Ref RouterELBSecurityGroup
+{%- if openshift_aws_num_masters > 1 %}
   MasterExternalELBSecurityGroups:
     Value:
       - !Ref MasterExternalELBSecurityGroup
   MasterInternalELBSecurityGroups:
     Value:
       - !Ref MasterInternalELBSecurityGroup
+{%- endif %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
@@ -1,3 +1,61 @@
+{%- from 'lib/security_groups.j2' import ssh, etcd, node, router, router_elb, master, master_external_elb, master_internal_elb, security_group_for_name, security_grouping_for_name%}
+{#- security_group emits a AWS::EC2::SecurityGroup definition for the named component #}
+{%- macro security_group(name) %}
+  {{ security_group_for_name(name) }}:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift {{ name }}s'
+      VpcId: !Ref VPC
+{%- endmacro -%}
+{#- external_ingress emits an AWS::EC2::SecurityGroupIngress definition for the named component from the internet #}
+{% macro external_ingress(destination, to_port, from_port='', identifier='') %}
+{%- if from_port == '' %}{% set from_port = to_port %}{% endif %}
+  {{ security_group_for_name(destination) ~ identifier }}Ingress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn: !Ref {{ security_group_for_name(destination) }}
+    Properties:
+      GroupId:    !Ref {{ security_group_for_name(destination) }}
+      CidrIp:     0.0.0.0/0
+      ToPort:     {{ to_port }}
+      FromPort:   {{ from_port }}
+      IpProtocol: tcp
+{%- endmacro -%}
+{#- internal_ingress emits an AWS::EC2::SecurityGroupIngress definition for the named component from another component #}
+{%- macro internal_ingress(destination, source, to_port, from_port='', identifier='', protocol='tcp') %}
+{%- if from_port == '' %}{% set from_port = to_port %}{% endif %}
+{%- if identifier == '' and source != destination %}{% set identifier = source %}{% endif %}
+  {{ security_group_for_name(destination) ~ identifier }}Ingress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref {{ security_group_for_name(source) }}
+{%- if source != destination %}
+      - !Ref {{ security_group_for_name(destination) }}
+{%- endif %}
+    Properties:
+      GroupId:               !Ref {{ security_group_for_name(destination) }}
+      SourceSecurityGroupId: !Ref {{ security_group_for_name(source) }}
+      ToPort:                {{ to_port }}
+      FromPort:              {{ from_port }}
+      IpProtocol:            {{ protocol }}
+{%- endmacro -%}
+{#- internal_egress emits an AWS::EC2::SecurityGroupEgress definition for the named component to another component #}
+{%- macro internal_egress(source, destination, to_port, from_port='', identifier='', protocol='tcp') %}
+{%- if from_port == '' %}{% set from_port = to_port %}{% endif %}
+{%- if identifier == '' and source != destination %}{% set identifier = destination %}{% endif %}
+  {{ security_group_for_name(destination) ~ identifier }}Ingress:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    DependsOn:
+      - !Ref {{ security_group_for_name(source) }}
+{%- if source != destination %}
+      - !Ref {{ security_group_for_name(destination) }}
+{%- endif %}
+    Properties:
+      GroupId:                    !Ref {{ security_group_for_name(source) }}
+      DestinationSecurityGroupId: !Ref {{ security_group_for_name(destination) }}
+      ToPort:                     {{ to_port }}
+      FromPort:                   {{ from_port }}
+      IpProtocol:                 {{ protocol }}
+{%- endmacro -%}
 AWSTemplateFormatVersion: '2010-09-09'
 Description: OpenShift Security Groups Template
 Parameters:
@@ -6,145 +64,58 @@ Parameters:
   MasterAPIPort:
     Type: Number
 
-{%- from 'cluster.j2' import security_group, security_groups %}
-
 Resources:
-{%- for group in security_groups + ['SSH'] %}
-  {{ security_group(group) }}:
-    Type: 'AWS::EC2::SecurityGroup'
-    Properties:
-      GroupDescription: 'OpenShift {{ group }}s'
-      VpcId: !Ref VPC
+{%- for name in [etcd, node, router, master, router_elb, ssh] -%}
+{{ security_group(name) }}
 {%- endfor %}
 
-{% macro external_ingress(destination, to_port, from_port='', identifier='') %}
-{%- if from_port == '' %}{%- set from_port = to_port %}{% endif -%}
-  {{ security_group(destination) ~ identifier }}Ingress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn: !Ref {{ security_group(destination) }}
-    Properties:
-      GroupId:    !Ref {{ security_group(destination) }}
-      CidrIp:     0.0.0.0/0
-      ToPort:     {{ to_port }}
-      FromPort:   {{ from_port }}
-      IpProtocol: tcp
-{%- endmacro %}
-
-{{ external_ingress(destination='SSH',                                   to_port=22                  ) }}
-{%- if openshift_aws_num_masters > 1 %}
-{{ external_ingress(destination='MasterExternalELB',                     to_port='!Ref MasterAPIPort') }}
-{%- endif %}
-{{ external_ingress(destination='RouterELB',         identifier='HTTP',  to_port=80                  ) }}
-{{ external_ingress(destination='RouterELB',         identifier='HTTPS', to_port=443                 ) }}
-
-{%- macro internal_ingress(destination, source, to_port, from_port='', identifier='', protocol='tcp') %}
-{%- if from_port == '' %}{%- set from_port = to_port %}{% endif -%}
-{%- if identifier == '' %}{%- set identifier = source %}{% endif -%}
-  {{ security_group(destination) ~ identifier }}Ingress:
-    Type: 'AWS::EC2::SecurityGroupIngress'
-    DependsOn:
-      - !Ref {{ security_group(source) }}
-{%- if source != destination %}
-      - !Ref {{ security_group(destination) }}
-{%- endif %}
-    Properties:
-      GroupId:               !Ref {{ security_group(destination) }}
-      SourceSecurityGroupId: !Ref {{ security_group(source) }}
-      ToPort:                {{ to_port }}
-      FromPort:              {{ from_port }}
-      IpProtocol:            {{ protocol }}
-{%- endmacro %}
-
-{{ internal_ingress(destination='ETCD',              source='Master',                                  to_port=2379                ) }}
-{{ internal_ingress(destination='ETCD',              source='ETCD',                                    to_port=2380, from_port=2379) }}
-{{ internal_ingress(destination='Node',              source='Master',                                  to_port=10250               ) }}
-{{ internal_ingress(destination='Node',              source='Node',              identifier='Kubelet', to_port=10250               ) }}
-{{ internal_ingress(destination='Node',              source='Node',              identifier='VXLAN',   to_port=4789, protocol='udp') }}
-{{ internal_ingress(destination='Master',            source='Master',            identifier='API',     to_port='!Ref MasterAPIPort') }}
-{{ internal_ingress(destination='Master',            source='Node',                                    to_port='!Ref MasterAPIPort') }}
-{%- if openshift_aws_num_masters > 1 %}
-{{ internal_ingress(destination='Master',            source='MasterInternalELB',                       to_port='!Ref MasterAPIPort') }}
-{{ internal_ingress(destination='Master',            source='MasterExternalELB',                       to_port='!Ref MasterAPIPort') }}
-{{ internal_ingress(destination='MasterInternalELB', source='Master',                                  to_port='!Ref MasterAPIPort') }}
-{{ internal_ingress(destination='MasterInternalELB', source='Node',                                    to_port='!Ref MasterAPIPort') }}
-{%- endif %}
-{{ internal_ingress(destination='Router',            source='RouterELB',         identifier='HTTP',    to_port=80                  ) }}
-{{ internal_ingress(destination='Router',            source='RouterELB',         identifier='HTTPS',   to_port=443                 ) }}
-
+{{ external_ingress(destination=ssh,                                                                        to_port=22                  ) -}}
+{{ external_ingress(destination=router_elb,                                           identifier='HTTP',    to_port=80                  ) -}}
+{{ external_ingress(destination=router_elb,                                           identifier='HTTPS',   to_port=443                 ) -}}
+{{ internal_ingress(destination=etcd,                source=master,                                         to_port=2379                ) -}}
+{{ internal_ingress(destination=etcd,                source=etcd,                                           to_port=2380, from_port=2379) -}}
+{{ internal_ingress(destination=node,                source=master,                                         to_port=10250               ) -}}
+{{ internal_ingress(destination=node,                source=node,                     identifier='Kubelet', to_port=10250               ) -}}
+{{ internal_ingress(destination=node,                source=node,                     identifier='VXLAN',   to_port=4789, protocol='udp') -}}
+{{ internal_ingress(destination=master,              source=master,                   identifier='API',     to_port='!Ref MasterAPIPort') -}}
+{{ internal_ingress(destination=master,              source=node,                                           to_port='!Ref MasterAPIPort') -}}
+{{ internal_ingress(destination=router,              source=router_elb,               identifier='HTTP',    to_port=80                  ) -}}
+{{ internal_ingress(destination=router,              source=router_elb,               identifier='HTTPS',   to_port=443                 ) -}}
+{{  internal_egress(source=router_elb,               destination=router_elb,          identifier='HTTP',    to_port=80                  ) -}}
+{{  internal_egress(source=router_elb,               destination=router_elb,          identifier='HTTPS',   to_port=443                 ) -}}
 
 {%- if openshift_aws_num_masters > 1 %}
-  MasterExternalELBSecurityGroupEgress:
-    Type: 'AWS::EC2::SecurityGroupEgress'
-    DependsOn: !Ref MasterExternalELBSecurityGroup
-    Properties:
-      GroupId:                    !Ref MasterExternalELBSecurityGroup
-      DestinationSecurityGroupId: !Ref MasterExternalELBSecurityGroup
-      ToPort:                     !Ref MasterAPIPort
-      FromPort:                   !Ref MasterAPIPort
-      IpProtocol:                 tcp
-{%- endif %}
+{%- for name in [master_external_elb, master_internal_elb] -%}
+{{ security_group(name) }}
+{%- endfor %}
 
-  RouterELBSecurityGroupHTTPEgress:
-    Type: 'AWS::EC2::SecurityGroupEgress'
-    DependsOn: !Ref RouterELBSecurityGroup
-    Properties:
-      GroupId:                    !Ref RouterELBSecurityGroup
-      DestinationSecurityGroupId: !Ref RouterELBSecurityGroup
-      ToPort:                     80
-      FromPort:                   80
-      IpProtocol:                 tcp
-  RouterELBSecurityGroupHTTPSEgress:
-    Type: 'AWS::EC2::SecurityGroupEgress'
-    DependsOn: !Ref RouterELBSecurityGroup
-    Properties:
-      GroupId:                    !Ref RouterELBSecurityGroup
-      DestinationSecurityGroupId: !Ref RouterELBSecurityGroup
-      ToPort:                     443
-      FromPort:                   443
-      IpProtocol:                 tcp
-
-{%- if openshift_aws_num_masters > 1 %}
-  MasterInternalELBSecurityGroupMasterEgress:
-    Type: 'AWS::EC2::SecurityGroupEgress'
-    DependsOn:
-      - !Ref MasterExternalELBSecurityGroup
-      - !Ref MasterSecurityGroup
-    Properties:
-      GroupId:                    !Ref MasterExternalELBSecurityGroup
-      DestinationSecurityGroupId: !Ref MasterSecurityGroup
-      ToPort:                     !Ref MasterAPIPort
-      FromPort:                   !Ref MasterAPIPort
-      IpProtocol:                 tcp
+{{ external_ingress(destination=master_external_elb,                                                        to_port='!Ref MasterAPIPort') -}}
+{{ internal_ingress(destination=master,              source=master_internal_elb,                            to_port='!Ref MasterAPIPort') -}}
+{{ internal_ingress(destination=master,              source=master_external_elb,                            to_port='!Ref MasterAPIPort') -}}
+{{ internal_ingress(destination=master_internal_elb, source=master,                                         to_port='!Ref MasterAPIPort') -}}
+{{ internal_ingress(destination=master_internal_elb, source=node,                                           to_port='!Ref MasterAPIPort') -}}
+{{  internal_egress(source=master_external_elb,      destination=master_external_elb,                       to_port='!Ref MasterAPIPort') -}}
+{{  internal_egress(source=master_internal_elb,      destination=master_internal_elb,                       to_port='!Ref MasterAPIPort') -}}
 {%- endif %}
 
 Outputs:
-  MasterSecurityGroups:
-    Value:
-      - !Ref MasterSecurityGroup
-      - !Ref NodeSecurityGroup
-      - !Ref ETCDSecurityGroup
-      - !Ref SSHSecurityGroup
-  NodeSecurityGroups:
-    Value:
-      - !Ref NodeSecurityGroup
-      - !Ref SSHSecurityGroup
-  ETCDSecurityGroups:
-    Value:
-      - !Ref ETCDSecurityGroup
-      - !Ref SSHSecurityGroup
-  RouterSecurityGroups:
-    Value:
-      - !Ref RouterSecurityGroup
-      - !Ref NodeSecurityGroup
-      - !Ref SSHSecurityGroup
-  RouterELBSecurityGroups:
-    Value:
-      - !Ref RouterELBSecurityGroup
+{%- set security_grouping_mapping = [
+	(master,     [master, node, etcd, ssh]),
+	(node,       [node, ssh]),
+	(etcd,       [etcd, ssh]),
+	(router,     [router, node, ssh]),
+	(router_elb, [router_elb])
+] %}
 {%- if openshift_aws_num_masters > 1 %}
-  MasterExternalELBSecurityGroups:
-    Value:
-      - !Ref MasterExternalELBSecurityGroup
-  MasterInternalELBSecurityGroups:
-    Value:
-      - !Ref MasterInternalELBSecurityGroup
+{%- set security_grouping_mapping = security_grouping_mapping + [
+	(master_external_elb, [master_external_elb]),
+	(master_internal_elb, [master_internal_elb]),
+] %}
 {%- endif %}
+{%- for name, constituents in security_grouping_mapping %}
+  {{ security_grouping_for_name(name) }}:
+    Value:
+{%- for part in constituents %}
+      - !Ref {{ security_group_for_name(part) }}
+{%- endfor %}
+{%- endfor %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/security_groups.j2
@@ -1,0 +1,303 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: OpenShift Security Groups Template
+Parameters:
+  VPC:
+    Type: "AWS::EC2::VPC::Id"
+  MasterAPIPort:
+    Type: Number
+
+Resources:
+  MasterSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift Masters'
+      VpcId: !Ref VPC
+  MasterExternalELBSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift Masters External Load-Balancer'
+      VpcId: !Ref VPC
+  MasterInternalELBSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift Masters Internal Load-Balancer'
+      VpcId: !Ref VPC
+  NodeSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift Nodes'
+      VpcId: !Ref VPC
+  ETCDSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift etcd Hosts'
+      VpcId: !Ref VPC
+  RouterSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift Routers'
+      VpcId: !Ref VPC
+  RouterELBSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'OpenShift Routers Load-Balancer'
+      VpcId: !Ref VPC
+  SSHSecurityGroup:
+    Type: 'AWS::EC2::SecurityGroup'
+    Properties:
+      GroupDescription: 'SSH Access'
+      VpcId: !Ref VPC
+
+  SSHSecurityGroupIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn: !Ref SSHSecurityGroup
+    Properties:
+      GroupId:    !Ref SSHSecurityGroup
+      CidrIp:     0.0.0.0/0
+      ToPort:     22
+      FromPort:   22
+      IpProtocol: tcp
+
+  MasterExternalELBSecurityGroupIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn: !Ref MasterExternalELBSecurityGroup
+    Properties:
+      GroupId:    !Ref MasterExternalELBSecurityGroup
+      CidrIp:     0.0.0.0/0
+      ToPort:     !Ref MasterAPIPort
+      FromPort:   !Ref MasterAPIPort
+      IpProtocol: tcp
+
+  RouterELBSecurityGroupHTTPIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn: !Ref RouterELBSecurityGroup
+    Properties:
+      GroupId:    !Ref RouterELBSecurityGroup
+      CidrIp:     0.0.0.0/0
+      ToPort:     80
+      FromPort:   80
+      IpProtocol: tcp
+  RouterELBSecurityGroupHTTPsIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn: !Ref RouterELBSecurityGroup
+    Properties:
+      GroupId:    !Ref RouterELBSecurityGroup
+      CidrIp:     0.0.0.0/0
+      ToPort:     443
+      FromPort:   443
+      IpProtocol: tcp
+
+  ETCDSecurityGroupMasterIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref ETCDSecurityGroup
+      - !Ref MasterSecurityGroup
+    Properties:
+      GroupId:               !Ref ETCDSecurityGroup
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+      ToPort:                2379
+      FromPort:              2379
+      IpProtocol:            tcp
+  ETCDSecurityGroupETCDIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref ETCDSecurityGroup
+    Properties:
+      GroupId:               !Ref ETCDSecurityGroup
+      SourceSecurityGroupId: !Ref ETCDSecurityGroup
+      ToPort:                2380
+      FromPort:              2379
+      IpProtocol:            tcp
+
+  NodeSecurityGroupMasterIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref NodeSecurityGroup
+      - !Ref MasterSecurityGroup
+    Properties:
+      GroupId:               !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+      ToPort:                10250
+      FromPort:              10250
+      IpProtocol:            tcp
+  NodeSecurityGroupKubeletIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref NodeSecurityGroup
+    Properties:
+      GroupId:               !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort:                10250
+      FromPort:              10250
+      IpProtocol:            tcp
+  NodeSecurityGroupVXLANIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref NodeSecurityGroup
+    Properties:
+      GroupId:               !Ref NodeSecurityGroup
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort:                4789
+      FromPort:              4789
+      IpProtocol:            udp
+
+  MasterSecurityGroupMasterAPIIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref MasterSecurityGroup
+    Properties:
+      GroupId:               !Ref MasterSecurityGroup
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+      ToPort:                !Ref MasterAPIPort
+      FromPort:              !Ref MasterAPIPort
+      IpProtocol:            tcp
+  MasterSecurityGroupNodeIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref MasterSecurityGroup
+      - !Ref NodeSecurityGroup
+    Properties:
+      GroupId:               !Ref MasterSecurityGroup
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort:                !Ref MasterAPIPort
+      FromPort:              !Ref MasterAPIPort
+      IpProtocol:            tcp
+  MasterSecurityGroupMasterInternalELBIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref MasterSecurityGroup
+      - !Ref MasterInternalELBSecurityGroup
+    Properties:
+      GroupId:               !Ref MasterSecurityGroup
+      SourceSecurityGroupId: !Ref MasterInternalELBSecurityGroup
+      ToPort:                !Ref MasterAPIPort
+      FromPort:              !Ref MasterAPIPort
+      IpProtocol:            tcp
+  MasterSecurityGroupMasterExternalELBIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref MasterSecurityGroup
+      - !Ref MasterExternalELBSecurityGroup
+    Properties:
+      GroupId:               !Ref MasterSecurityGroup
+      SourceSecurityGroupId: !Ref MasterExternalELBSecurityGroup
+      ToPort:                !Ref MasterAPIPort
+      FromPort:              !Ref MasterAPIPort
+      IpProtocol:            tcp
+
+  MasterInternalELBSecurityGroupMasterIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref MasterInternalELBSecurityGroup
+      - !Ref MasterSecurityGroup
+    Properties:
+      GroupId:               !Ref MasterInternalELBSecurityGroup
+      SourceSecurityGroupId: !Ref MasterSecurityGroup
+      ToPort:                !Ref MasterAPIPort
+      FromPort:              !Ref MasterAPIPort
+      IpProtocol:            tcp
+  MasterInternalELBSecurityGroupNodeIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref MasterInternalELBSecurityGroup
+      - !Ref NodeSecurityGroup
+    Properties:
+      GroupId:               !Ref MasterInternalELBSecurityGroup
+      SourceSecurityGroupId: !Ref NodeSecurityGroup
+      ToPort:                !Ref MasterAPIPort
+      FromPort:              !Ref MasterAPIPort
+      IpProtocol:            tcp
+
+  RouterSecurityGroupHTTPIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref RouterSecurityGroup
+      - !Ref RouterELBSecurityGroup
+    Properties:
+      GroupId:               !Ref RouterSecurityGroup
+      SourceSecurityGroupId: !Ref RouterELBSecurityGroup
+      ToPort:                80
+      FromPort:              80
+      IpProtocol:            tcp
+  RouterSecurityGroupHTTPSIngress:
+    Type: 'AWS::EC2::SecurityGroupIngress'
+    DependsOn:
+      - !Ref RouterSecurityGroup
+      - !Ref RouterELBSecurityGroup
+    Properties:
+      GroupId:               !Ref RouterSecurityGroup
+      SourceSecurityGroupId: !Ref RouterELBSecurityGroup
+      ToPort:                443
+      FromPort:              443
+      IpProtocol:            tcp
+
+  MasterExternalELBSecurityGroupEgress:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    DependsOn: !Ref MasterExternalELBSecurityGroup
+    Properties:
+      GroupId:                    !Ref MasterExternalELBSecurityGroup
+      DestinationSecurityGroupId: !Ref MasterExternalELBSecurityGroup
+      ToPort:                     !Ref MasterAPIPort
+      FromPort:                   !Ref MasterAPIPort
+      IpProtocol:                 tcp
+
+  RouterELBSecurityGroupHTTPEgress:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    DependsOn: !Ref RouterELBSecurityGroup
+    Properties:
+      GroupId:                    !Ref RouterELBSecurityGroup
+      DestinationSecurityGroupId: !Ref RouterELBSecurityGroup
+      ToPort:                     80
+      FromPort:                   80
+      IpProtocol:                 tcp
+  RouterELBSecurityGroupHTTPSEgress:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    DependsOn: !Ref RouterELBSecurityGroup
+    Properties:
+      GroupId:                    !Ref RouterELBSecurityGroup
+      DestinationSecurityGroupId: !Ref RouterELBSecurityGroup
+      ToPort:                     443
+      FromPort:                   443
+      IpProtocol:                 tcp
+
+  MasterInternalELBSecurityGroupMasterEgress:
+    Type: 'AWS::EC2::SecurityGroupEgress'
+    DependsOn:
+      - !Ref MasterExternalELBSecurityGroup
+      - !Ref MasterSecurityGroup
+    Properties:
+      GroupId:                    !Ref MasterExternalELBSecurityGroup
+      DestinationSecurityGroupId: !Ref MasterSecurityGroup
+      ToPort:                     !Ref MasterAPIPort
+      FromPort:                   !Ref MasterAPIPort
+      IpProtocol:                 tcp
+
+Outputs:
+  MasterSecurityGroups:
+    Value:
+      - !Ref MasterSecurityGroup
+      - !Ref NodeSecurityGroup
+      - !Ref ETCDSecurityGroup
+      - !Ref SSHSecurityGroup
+  NodeSecurityGroups:
+    Value:
+      - !Ref NodeSecurityGroup
+      - !Ref SSHSecurityGroup
+  ETCDSecurityGroups:
+    Value:
+      - !Ref ETCDSecurityGroup
+      - !Ref SSHSecurityGroup
+  RouterSecurityGroups:
+    Value:
+      - !Ref RouterSecurityGroup
+      - !Ref NodeSecurityGroup
+      - !Ref SSHSecurityGroup
+  RouterELBSecurityGroups:
+    Value:
+      - !Ref RouterELBSecurityGroup
+  MasterExternalELBSecurityGroups:
+    Value:
+      - !Ref MasterExternalELBSecurityGroup
+  MasterInternalELBSecurityGroups:
+    Value:
+      - !Ref MasterInternalELBSecurityGroup

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/vpc.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/vpc.j2
@@ -1,0 +1,60 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: OpenShift VPC and Subnet Template
+Parameters:
+  VPCCIDRBlock:
+    Type: String
+  SubnetCIDRBlocks:
+    Type: CommaDelimitedList
+  SubnetAvailabilityZones:
+    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
+
+Resources:
+  VPC:
+    Type: 'AWS::EC2::VPC'
+    Properties:
+      CidrBlock:          !Ref VPCCIDRBlock
+      EnableDnsSupport:   True
+      EnableDnsHostnames: True
+  VPCInternetGateway:
+    Type: 'AWS::EC2::InternetGateway'
+    Properties: {}
+  VPCGatewayAttachment:
+    Type: 'AWS::EC2::VPCGatewayAttachment'
+    Properties:
+      VpcId:             !Ref VPC
+      InternetGatewayId: !Ref VPCInternetGateway
+  VPCRouteTable:
+    Type: 'AWS::EC2::RouteTable'
+    Properties:
+      VpcId: !Ref VPC
+  VPCRoute:
+    Type: 'AWS::EC2::Route'
+    Properties:
+      GatewayId:            !Ref VPCInternetGateway
+      RouteTableId:         !Ref VPCRouteTable
+      DestinationCIDRBlock: 0.0.0.0/0
+{%- for i in range(openshift_aws_num_subnets) %}
+  Subnet{{ i }}:
+    Type: 'AWS::EC2::Subnet'
+    DependsOn:
+      - VPCIdentifier
+    Properties:
+      VpcId:               !Ref VPC
+      CidrBlock:           !Select [{{ i }}, !Ref SubnetCIDRBlocks]
+      AvailabilityZone:    !Select [{{ i }}, !Ref SubnetAvailabilityZones]
+      MapPublicIpOnLaunch: True
+  Subnet{{ i }}RouteTableAssociation:
+    Type: 'AWS::EC2::SubnetRouteTableAssociation'
+    Properties:
+      SubnetId:     !Ref Subnet{{ i }}
+      RouteTableId: !Ref VPCRouteTable
+{%- endfor %}
+
+Outputs:
+  VPC:
+    Value: !Ref VPC
+  MasterInstanceSubnets:
+    Value:
+{%- for i in range(openshift_aws_num_subnets) %}
+      - !Ref Subnet{{i}}
+{%- endfor %}

--- a/playbooks/provisioning/aws/cloudformation-jinja/templates/vpc.j2
+++ b/playbooks/provisioning/aws/cloudformation-jinja/templates/vpc.j2
@@ -33,7 +33,7 @@ Resources:
       GatewayId:            !Ref VPCInternetGateway
       RouteTableId:         !Ref VPCRouteTable
       DestinationCIDRBlock: 0.0.0.0/0
-{%- for i in range(openshift_aws_num_subnets) %}
+{%- for i in range(openshift_aws_num_masters) %}
   Subnet{{ i }}:
     Type: 'AWS::EC2::Subnet'
     DependsOn:
@@ -55,6 +55,6 @@ Outputs:
     Value: !Ref VPC
   MasterInstanceSubnets:
     Value:
-{%- for i in range(openshift_aws_num_subnets) %}
+{%- for i in range(openshift_aws_num_masters) %}
       - !Ref Subnet{{i}}
 {%- endfor %}


### PR DESCRIPTION
Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

Sample `cluster` template without VPC/IAM/SG:
```yaml
AWSTemplateFormatVersion: '2010-09-09'
Description: OpenShift Cluster Template
Parameters:
  NamePrefix:
    Type: String
  MasterAPIPort:
    Type: Number
  KeyName:
    Type: 'AWS::EC2::KeyPair::KeyName'
  VPC:
    Type: 'AWS::EC2::VPC::Id'
  ETCDSecurityGroups:
    Type: 'List<AWS::EC2::SecurityGroup::Id>'
  NodeSecurityGroups:
    Type: 'List<AWS::EC2::SecurityGroup::Id>'
  RouterSecurityGroups:
    Type: 'List<AWS::EC2::SecurityGroup::Id>'
  MasterSecurityGroups:
    Type: 'List<AWS::EC2::SecurityGroup::Id>'
  RouterELBSecurityGroups:
    Type: 'List<AWS::EC2::SecurityGroup::Id>'
  MasterExternalELBSecurityGroups:
    Type: 'List<AWS::EC2::SecurityGroup::Id>'
  MasterInternalELBSecurityGroups:
    Type: 'List<AWS::EC2::SecurityGroup::Id>'
  MasterInstanceProfile:
    Type: String
  NodeInstanceProfile:
    Type: String
  MasterUserData:
    Type: String
  MasterInstanceSubnets:
    Type: 'List<AWS::EC2::Subnet::Id>'
  ControlPlaneTemplateURL:
    Type: String
    Default: 'https://s3.amazonaws.com/openshift-cloudformation-templates/control-plane/default.yaml'

Resources:
  ControlPlaneStack:
    Type: 'AWS::CloudFormation::Stack'
    Properties:
      TemplateURL: !Ref ControlPlaneTemplateURL
      Parameters:
        KeyName:                         !Ref KeyName
        MasterSubnets:                   !Ref MasterInstanceSubnets
        MasterAPIPort:                   !Ref MasterAPIPort
        MasterUserData:                  !Ref MasterUserData
        NodeInstanceProfile:             !Ref NodeInstanceProfile
        MasterInstanceProfile:           !Ref MasterInstanceProfile
        ETCDSecurityGroups:              !Ref ETCDSecurityGroups
        NodeSecurityGroups:              !Ref NodeSecurityGroups
        RouterSecurityGroups:            !Ref RouterSecurityGroups
        MasterSecurityGroups:            !Ref MasterSecurityGroups
        RouterELBSecurityGroups:         !Ref RouterELBSecurityGroups
        MasterExternalELBSecurityGroups: !Ref MasterExternalELBSecurityGroups
        MasterInternalELBSecurityGroups: !Ref MasterInternalELBSecurityGroups
```

Now with them all:
```yaml
AWSTemplateFormatVersion: '2010-09-09'
Description: OpenShift Cluster Template
Parameters:
  NamePrefix:
    Type: String
  MasterAPIPort:
    Type: Number
  KeyName:
    Type: 'AWS::EC2::KeyPair::KeyName'
  VPCTemplateURL:
    Type: String
    Default: 'https://s3.amazonaws.com/openshift-cloudformation-templates/vpc/default.yaml'
  VPCCIDRBlock:
    Type: String
  SubnetCIDRBlocks:
    Type: CommaDelimitedList
  SubnetAvailabilityZones:
    Type: 'List<AWS::EC2::AvailabilityZone::Name>'
  SecurityGroupTemplateURL:
    Type: String
    Default: 'https://s3.amazonaws.com/openshift-cloudformation-templates/security-groups/default.yaml'
  IAMInstanceProfileTemplateURL:
    Type: String
    Default: 'https://s3.amazonaws.com/openshift-cloudformation-templates/iam-profiles/default.yaml'
  MasterUserData:
    Type: String
  MasterInstanceSubnets:
    Type: 'List<AWS::EC2::Subnet::Id>'
  ControlPlaneTemplateURL:
    Type: String
    Default: 'https://s3.amazonaws.com/openshift-cloudformation-templates/control-plane/default.yaml'

Resources:
  VPCStack:
    Type: 'AWS::CloudFormation::Stack'
    Properties:
      TemplateURL: !Ref VPCTemplateURL
      Parameters:
        VPCName:                 !Join ['', [!Ref NamePrefix, '_vpc']]
        VPCCIDRBlock:            !Ref VPCCIDRBlock
        SubnetCIDRBlocks:        !Ref SubnetCIDRBlocks
        SubnetAvailabilityZones: !Ref SubnetAvailabilityZones
  SecurityGroupStack:
    Type: 'AWS::CloudFormation::Stack'
    Properties:
      TemplateURL: !Ref SecurityGroupTemplateURL
      Parameters:
        VPC:           !GetAtt VPCStack.Outputs.VPC
        MasterAPIPort: !Ref MasterAPIPort
  IAMStack:
    Type: 'AWS::CloudFormation::Stack'
    Properties:
      TemplateURL: !Ref IAMInstanceProfileTemplateURL
  ControlPlaneStack:
    Type: 'AWS::CloudFormation::Stack'
    Properties:
      TemplateURL: !Ref ControlPlaneTemplateURL
      Parameters:
        KeyName:                         !Ref KeyName
        MasterSubnets:                   !GetAtt VPCStack.Outputs.MasterInstanceSubnets
        MasterAPIPort:                   !Ref MasterAPIPort
        MasterUserData:                  !Ref MasterUserData
        NodeInstanceProfile:             !GetAtt IAMStack.Outputs.NodeInstanceProfile
        MasterInstanceProfile:           !GetAtt IAMStack.Outputs.MasterInstanceProfile
        ETCDSecurityGroups:              !GetAtt SecurityGroupStack.Outputs.ETCDSecurityGroups
        NodeSecurityGroups:              !GetAtt SecurityGroupStack.Outputs.NodeSecurityGroups
        RouterSecurityGroups:            !GetAtt SecurityGroupStack.Outputs.RouterSecurityGroups
        MasterSecurityGroups:            !GetAtt SecurityGroupStack.Outputs.MasterSecurityGroups
        RouterELBSecurityGroups:         !GetAtt SecurityGroupStack.Outputs.RouterELBSecurityGroups
        MasterExternalELBSecurityGroups: !GetAtt SecurityGroupStack.Outputs.MasterExternalELBSecurityGroups
        MasterInternalELBSecurityGroups: !GetAtt SecurityGroupStack.Outputs.MasterInternalELBSecurityGroups
```